### PR TITLE
Add global Attributes to STATS.h5. Refactor HDF5 writer functions.

### DIFF
--- a/src/nisarqa/__init__.py
+++ b/src/nisarqa/__init__.py
@@ -116,6 +116,8 @@ from .parameters.rslc_caltools_params import *
 from .parameters.gslc_params import *
 from .parameters.gcov_params import *
 from .parameters.insar_params import *
+from .utils import typing
+from .utils.utils import *
 from .products.product_reader import *
 from .utils.file_verification.policy import *
 from .utils.file_verification.data_annotation import *
@@ -128,7 +130,6 @@ from .utils.file_verification.xml_check import *
 from .utils.file_verification.xml_parser import *
 
 from .utils.metadata_checks import *
-from .utils.utils import *
 
 # keep individual products in their own namespace
 from .products import (
@@ -150,6 +151,5 @@ from .utils.summary_csv import *
 from .utils.stats_h5_writer.metrics_writer import *
 from .utils.stats_h5_writer.setup_writer import *
 from .utils.sanity_checks import *
-from .utils import typing
 
 # isort: on

--- a/src/nisarqa/__main__.py
+++ b/src/nisarqa/__main__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import os
-
 import matplotlib
 
 # Switch backend to one that doesn't require DISPLAY to be set since we're
@@ -188,18 +186,29 @@ def run():
 
     # Run QA SAS
     verbose = args.verbose
-    if subcommand == "rslc_qa":
-        nisarqa.rslc.verify_rslc(root_params=root_params, verbose=verbose)
-    elif subcommand == "gslc_qa":
-        nisarqa.gslc.verify_gslc(root_params=root_params, verbose=verbose)
-    elif subcommand == "gcov_qa":
-        nisarqa.gcov.verify_gcov(root_params=root_params, verbose=verbose)
-    elif subcommand in ("rifg_qa", "runw_qa", "gunw_qa"):
-        nisarqa.igram.verify_igram(root_params=root_params, verbose=verbose)
-    elif subcommand in ("roff_qa", "goff_qa"):
-        nisarqa.offsets.verify_offset(root_params=root_params, verbose=verbose)
-    else:
-        raise ValueError(f"Unknown subcommand: {subcommand}")
+
+    with nisarqa.create_unique_subdirectory(
+        parent_dir=root_params.prodpath.scratch_dir_parent,
+        prefix=f"qa-{product_type}",
+        delete=root_params.software_config.delete_scratch_files,
+    ) as scratch_dir:
+
+        nisarqa.set_global_scratch_dir(scratch_dir)
+
+        if subcommand == "rslc_qa":
+            nisarqa.rslc.verify_rslc(root_params=root_params, verbose=verbose)
+        elif subcommand == "gslc_qa":
+            nisarqa.gslc.verify_gslc(root_params=root_params, verbose=verbose)
+        elif subcommand == "gcov_qa":
+            nisarqa.gcov.verify_gcov(root_params=root_params, verbose=verbose)
+        elif subcommand in ("rifg_qa", "runw_qa", "gunw_qa"):
+            nisarqa.igram.verify_igram(root_params=root_params, verbose=verbose)
+        elif subcommand in ("roff_qa", "goff_qa"):
+            nisarqa.offsets.verify_offset(
+                root_params=root_params, verbose=verbose
+            )
+        else:
+            raise ValueError(f"Unknown subcommand: {subcommand}")
 
 
 def main():

--- a/src/nisarqa/parameters/constants/globals.py
+++ b/src/nisarqa/parameters/constants/globals.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from functools import cache
 from itertools import product
 from pathlib import Path
 
@@ -143,6 +142,7 @@ def get_possible_pols(product_type):
 PRODUCT_SPECS_PATH = Path(__file__).parent.parent / "product_specs"
 
 complex32 = np.dtype([("r", np.float16), ("i", np.float16)])
+
 
 # The are global constants and not functions nor classes,
 # so manually create the __all__ attribute.

--- a/src/nisarqa/parameters/gcov_params.py
+++ b/src/nisarqa/parameters/gcov_params.py
@@ -9,6 +9,7 @@ from nisarqa.parameters.nisar_params import (
     InputFileGroupParamGroup,
     ProductPathGroupParamGroup,
     RootParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
 )
@@ -103,6 +104,8 @@ class GCOVRootParamGroup(RootParamGroup):
         Input File Group parameters for QA
     prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -110,10 +113,6 @@ class GCOVRootParamGroup(RootParamGroup):
     histogram : GCOVHistogramParamGroup or None, optional
         Histogram Group parameters for GCOV QA
     """
-
-    # Shared parameters
-    input_f: Optional[InputFileGroupParamGroup] = None
-    prodpath: Optional[ProductPathGroupParamGroup] = None
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -137,6 +136,11 @@ class GCOVRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=ProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -165,6 +169,7 @@ class GCOVRootParamGroup(RootParamGroup):
             "input_f": InputFileGroupParamGroup,
             "prodpath": ProductPathGroupParamGroup,
             "workflows": WorkflowsParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": GCOVHistogramParamGroup,

--- a/src/nisarqa/parameters/gslc_params.py
+++ b/src/nisarqa/parameters/gslc_params.py
@@ -11,6 +11,7 @@ from nisarqa import (
     ProductPathGroupParamGroup,
     RootParamGroup,
     SLCWorkflowsParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     YamlAttrs,
 )
@@ -104,6 +105,8 @@ class GSLCRootParamGroup(RootParamGroup):
         Input File Group parameters for QA
     prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -116,10 +119,8 @@ class GSLCRootParamGroup(RootParamGroup):
         Point Target Analyzer group parameters for GSLC QA-Caltools
     """
 
-    # Shared parameters
-    workflows: (
-        SLCWorkflowsParamGroup  # overwrite parent's `workflows` b/c new type
-    )
+    # Overwrite parent's attributes b/c new type
+    workflows: SLCWorkflowsParamGroup
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -185,6 +186,11 @@ class GSLCRootParamGroup(RootParamGroup):
                 param_grp_cls_obj=ProductPathGroupParamGroup,
             ),
             Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigParamGroup,
+            ),
+            Grp(
                 flag_param_grp_req=workflows.validate,
                 root_param_grp_attr_name="validation",
                 param_grp_cls_obj=ValidationGroupParamGroup,
@@ -222,6 +228,7 @@ class GSLCRootParamGroup(RootParamGroup):
             "anc_files": GSLCDynamicAncillaryFileParamGroup,
             "prodpath": ProductPathGroupParamGroup,
             "workflows": SLCWorkflowsParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/parameters/insar_params.py
+++ b/src/nisarqa/parameters/insar_params.py
@@ -13,6 +13,7 @@ from nisarqa import (
     InputFileGroupParamGroup,
     ProductPathGroupParamGroup,
     RootParamGroup,
+    SoftwareConfigParamGroup,
     Threshold99ParamGroup,
     ThresholdParamGroup,
     ValidationGroupParamGroup,
@@ -287,6 +288,41 @@ class GOFFWorkflowsParamGroup(WorkflowsParamGroup):
     @staticmethod
     def get_path_to_group_in_runconfig():
         return ["runconfig", "groups", "qa", "goff", "workflows"]
+
+
+@dataclass(frozen=True)
+class RIFGSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "rifg", "software_config"]
+
+
+@dataclass(frozen=True)
+class RUNWSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "runw", "software_config"]
+
+
+@dataclass(frozen=True)
+class GUNWSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "gunw", "software_config"]
+
+
+@dataclass(frozen=True)
+class ROFFSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "roff", "software_config"]
+
+
+@dataclass(frozen=True)
+class GOFFSoftwareConfigParamGroup(SoftwareConfigParamGroup):
+    @staticmethod
+    def get_path_to_group_in_runconfig():
+        return ["runconfig", "groups", "qa", "goff", "software_config"]
 
 
 @dataclass(frozen=True)
@@ -1684,6 +1720,8 @@ class RIFGRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : RIFGProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : RIFGSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : RIFGValidationParamGroup or None, optional
         Validation Group parameters for QA
     wrapped_igram : RIFGWrappedIgramParamGroup or None, optional
@@ -1703,6 +1741,7 @@ class RIFGRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[RIFGInputFileGroupParamGroup] = None
     prodpath: Optional[RIFGProductPathGroupParamGroup] = None
+    software_config: Optional[RIFGSoftwareConfigParamGroup] = None
     validation: Optional[RIFGValidationParamGroup] = None
 
     wrapped_igram: Optional[RIFGWrappedIgramParamGroup] = None
@@ -1729,6 +1768,11 @@ class RIFGRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=RIFGProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=RIFGSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1772,6 +1816,7 @@ class RIFGRootParamGroup(RootParamGroup):
             "input_f": RIFGInputFileGroupParamGroup,
             "prodpath": RIFGProductPathGroupParamGroup,
             "workflows": RIFGWorkflowsParamGroup,
+            "software_config": RIFGSoftwareConfigParamGroup,
             "validation": RIFGValidationParamGroup,
             "wrapped_igram": RIFGWrappedIgramParamGroup,
             "coh_mag": RIFGCohMagLayerParamGroup,
@@ -1801,6 +1846,8 @@ class RUNWRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : RUNWProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : RUNWSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : RUNWValidationParamGroup or None, optional
         Validation Group parameters for QA
     unw_phs_img : RUNWPhaseImageParamGroup or None, optional
@@ -1825,6 +1872,7 @@ class RUNWRootParamGroup(RootParamGroup):
     workflows: RUNWWorkflowsParamGroup
     input_f: Optional[RUNWInputFileGroupParamGroup] = None
     prodpath: Optional[RUNWProductPathGroupParamGroup] = None
+    software_config: Optional[RUNWSoftwareConfigParamGroup] = None
     validation: Optional[RUNWValidationParamGroup] = None
 
     unw_phs_img: Optional[RUNWPhaseImageParamGroup] = None
@@ -1854,6 +1902,11 @@ class RUNWRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=RUNWProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=RUNWSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -1912,6 +1965,7 @@ class RUNWRootParamGroup(RootParamGroup):
             "input_f": RUNWInputFileGroupParamGroup,
             "prodpath": RUNWProductPathGroupParamGroup,
             "workflows": RUNWWorkflowsParamGroup,
+            "software_config": RUNWSoftwareConfigParamGroup,
             "validation": RUNWValidationParamGroup,
             "unw_phs_img": RUNWPhaseImageParamGroup,
             "coh_mag": RUNWCohMagLayerParamGroup,
@@ -1944,6 +1998,8 @@ class GUNWRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : GUNWProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : GUNWSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : GUNWValidationParamGroup or None, optional
         Validation Group parameters for QA
     unw_phs_img : GUNWPhaseImageParamGroup or None, optional
@@ -1973,6 +2029,7 @@ class GUNWRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[GUNWInputFileGroupParamGroup] = None
     prodpath: Optional[GUNWProductPathGroupParamGroup] = None
+    software_config: Optional[GUNWSoftwareConfigParamGroup] = None
     validation: Optional[GUNWValidationParamGroup] = None
 
     unw_phs_img: Optional[GUNWPhaseImageParamGroup] = None
@@ -2003,6 +2060,11 @@ class GUNWRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=GUNWProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=GUNWSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2066,6 +2128,7 @@ class GUNWRootParamGroup(RootParamGroup):
             "input_f": GUNWInputFileGroupParamGroup,
             "prodpath": GUNWProductPathGroupParamGroup,
             "workflows": GUNWWorkflowsParamGroup,
+            "software_config": GUNWSoftwareConfigParamGroup,
             "validation": GUNWValidationParamGroup,
             "unw_phs_img": GUNWPhaseImageParamGroup,
             "wrapped_igram": GUNWWrappedIgramParamGroup,
@@ -2099,6 +2162,8 @@ class ROFFRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : ROFFProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : ROFFSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ROFFValidationParamGroup or None, optional
         Validation Group parameters for QA
     az_rng_offsets : ROFFAzAndRangeOffsetsParamGroup or None, optional
@@ -2118,6 +2183,7 @@ class ROFFRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[ROFFInputFileGroupParamGroup] = None
     prodpath: Optional[ROFFProductPathGroupParamGroup] = None
+    software_config: Optional[ROFFSoftwareConfigParamGroup] = None
     validation: Optional[ROFFValidationParamGroup] = None
 
     az_rng_offsets: Optional[ROFFAzAndRangeOffsetsParamGroup] = None
@@ -2144,6 +2210,11 @@ class ROFFRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=ROFFProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=ROFFSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2187,6 +2258,7 @@ class ROFFRootParamGroup(RootParamGroup):
             "input_f": ROFFInputFileGroupParamGroup,
             "prodpath": ROFFProductPathGroupParamGroup,
             "workflows": ROFFWorkflowsParamGroup,
+            "software_config": ROFFSoftwareConfigParamGroup,
             "validation": ROFFValidationParamGroup,
             "az_rng_offsets": ROFFAzAndRangeOffsetsParamGroup,
             "quiver": ROFFQuiverParamGroup,
@@ -2216,6 +2288,8 @@ class GOFFRootParamGroup(RootParamGroup):
         Input File Group parameters.
     prodpath : GOFFProductPathGroupParamGroup or None, optional
         Product Path Group parameters.
+    software_config : GOFFSoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : VerificationGroupParamGroup or None, optional
         Validation Group parameters for QA
     az_rng_offsets : GOFFAzAndRangeOffsetsParamGroup or None, optional
@@ -2235,6 +2309,7 @@ class GOFFRootParamGroup(RootParamGroup):
     # Shared parameters
     input_f: Optional[GOFFInputFileGroupParamGroup] = None
     prodpath: Optional[GOFFProductPathGroupParamGroup] = None
+    software_config: Optional[GOFFSoftwareConfigParamGroup] = None
     validation: Optional[GOFFValidationParamGroup] = None
 
     az_rng_offsets: Optional[GOFFAzAndRangeOffsetsParamGroup] = None
@@ -2261,6 +2336,11 @@ class GOFFRootParamGroup(RootParamGroup):
                 flag_param_grp_req=flag_any_workflows_true,
                 root_param_grp_attr_name="prodpath",
                 param_grp_cls_obj=GOFFProductPathGroupParamGroup,
+            ),
+            Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=GOFFSoftwareConfigParamGroup,
             ),
             Grp(
                 flag_param_grp_req=workflows.validate,
@@ -2304,6 +2384,7 @@ class GOFFRootParamGroup(RootParamGroup):
             "input_f": GOFFInputFileGroupParamGroup,
             "prodpath": GOFFProductPathGroupParamGroup,
             "workflows": GOFFWorkflowsParamGroup,
+            "software_config": GOFFSoftwareConfigParamGroup,
             "validation": GOFFValidationParamGroup,
             "az_rng_offsets": GOFFAzAndRangeOffsetsParamGroup,
             "quiver": GOFFQuiverParamGroup,

--- a/src/nisarqa/parameters/nisar_params.py
+++ b/src/nisarqa/parameters/nisar_params.py
@@ -1430,14 +1430,14 @@ class RootParamGroup(ABC):
         Parameters
         ----------
         h5_file : h5py.File
-            Handle to an h5 file where the processing metadata should be saved.
+            Handle to an HDF5 file where processing metadata should be saved.
         band : str
             The letter of the band. Ex: "L" or "S".
         """
         for params_obj in fields(self):
             po = getattr(self, params_obj.name)
             # If a workflow was not requested, its RootParams attribute
-            # will be None, so there will be no params to add to the h5 file
+            # will be None, so there will be no params to add to the HDF5 file
             if po is not None:
                 if issubclass(type(po), HDF5ParamGroup):
                     po.write_params_to_h5(h5_file, band=band)

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -1080,7 +1080,7 @@ class RSLCRootParamGroup(RootParamGroup):
                 # RootParamGroup.save_processing_params_to_stats_h5():
                 #       If a workflow was not requested, its RootParams
                 #       attribute will be None, so there will be no params to
-                #       add to the h5 file."
+                #       add to the HDF5 file."
                 # In nominal cases, these groups are set to None during
                 # `from_runconfig_dict()`. But, that step occurs prior to
                 # checking whether a corner reflector file was provided,

--- a/src/nisarqa/parameters/rslc_caltools_params.py
+++ b/src/nisarqa/parameters/rslc_caltools_params.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numbers
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field, fields, replace
-from typing import ClassVar, Optional, Type, Union
+from typing import ClassVar, Optional, Union
 
 import numpy as np
 from matplotlib.colors import to_rgba
@@ -18,6 +18,7 @@ from nisarqa import (
     ProductPathGroupParamGroup,
     RootParamGroup,
     RSLCPointTargetAnalyzerParamGroup,
+    SoftwareConfigParamGroup,
     ValidationGroupParamGroup,
     WorkflowsParamGroup,
     YamlAttrs,
@@ -999,6 +1000,8 @@ class RSLCRootParamGroup(RootParamGroup):
         Input File Group parameters for RSLC QA
     prodpath : ProductPathGroupParamGroup or None, optional
         Product Path Group parameters for RSLC QA
+    software_config : SoftwareConfigParamGroup or None, optional
+        General QA Software Configuration Group parameters
     validation : ValidationGroupParamGroup or None, optional
         Validation Group parameters for QA
     backscatter_img : BackscatterImageParamGroup or None, optional
@@ -1017,10 +1020,8 @@ class RSLCRootParamGroup(RootParamGroup):
         Point Target Analyzer group parameters for RSLC QA-Caltools
     """
 
-    # Shared parameters
-    workflows: (
-        RSLCWorkflowsParamGroup  # overwrite parent's `workflows` b/c new type
-    )
+    # Overwrite parent's attributes b/c new type
+    workflows: RSLCWorkflowsParamGroup
 
     # QA parameters
     backscatter_img: Optional[BackscatterImageParamGroup] = None
@@ -1133,6 +1134,11 @@ class RSLCRootParamGroup(RootParamGroup):
                 param_grp_cls_obj=ProductPathGroupParamGroup,
             ),
             Grp(
+                flag_param_grp_req=flag_any_workflows_true,
+                root_param_grp_attr_name="software_config",
+                param_grp_cls_obj=SoftwareConfigParamGroup,
+            ),
+            Grp(
                 flag_param_grp_req=workflows.validate,
                 root_param_grp_attr_name="validation",
                 param_grp_cls_obj=ValidationGroupParamGroup,
@@ -1185,6 +1191,7 @@ class RSLCRootParamGroup(RootParamGroup):
             "anc_files": DynamicAncillaryFileParamGroup,
             "prodpath": ProductPathGroupParamGroup,
             "workflows": RSLCWorkflowsParamGroup,
+            "software_config": SoftwareConfigParamGroup,
             "validation": ValidationGroupParamGroup,
             "backscatter_img": BackscatterImageParamGroup,
             "histogram": HistogramParamGroup,

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -138,16 +138,9 @@ def verify_gcov(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info from `pols` to stats file
             nisarqa.save_nisar_freq_metadata_to_h5(

--- a/src/nisarqa/products/gcov.py
+++ b/src/nisarqa/products/gcov.py
@@ -56,7 +56,11 @@ def verify_gcov(
     summary = nisarqa.get_summary()
 
     try:
-        product = nisarqa.GCOV(filepath=input_file)
+        product = nisarqa.GCOV(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -104,17 +104,6 @@ def verify_gslc(
         if not verbose:
             print(msg)
 
-    # If running these workflows, save the processing parameters and
-    # identification group to STATS.h5
-    if root_params.workflows.qa_reports or root_params.workflows.point_target:
-        # This is the first time opening the STATS.h5 file for GSLC
-        # workflow, so open in 'w' mode.
-        # After this, always open STATS.h5 in 'r+' mode.
-        with h5py.File(stats_file, mode="w") as stats_h5:
-            nisarqa.setup_stats_h5_all_products(
-                product=product, stats_h5=stats_h5, root_params=root_params
-            )
-
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -58,7 +58,11 @@ def verify_gslc(
     summary = nisarqa.get_summary()
 
     try:
-        product = nisarqa.GSLC(filepath=input_file)
+        product = nisarqa.GSLC(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -104,24 +104,6 @@ def verify_gslc(
         if not verbose:
             print(msg)
 
-    # If running these workflows, save the processing parameters and
-    # identification group to STATS.h5
-    if root_params.workflows.qa_reports or root_params.workflows.point_target:
-        # This is the first time opening the STATS.h5 file for RSLC
-        # workflow, so open in 'w' mode.
-        # After this, always open STATS.h5 in 'r+' mode.
-        with h5py.File(stats_file, mode="w") as stats_h5:
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
-            )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
-
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be
@@ -130,6 +112,21 @@ def verify_gslc(
     # steps. The file is automatically deleted upon closing if nothing was
     # written to it.
     with PdfPages(report_file, keep_empty=False) as report_pdf:
+
+        if (
+            root_params.workflows.qa_reports
+            or root_params.workflows.point_target
+        ):
+            # This is the first time opening the STATS.h5 file for GSLC
+            # workflow, so open in 'w' mode.
+            # After this, always open STATS.h5 in 'r+' mode.
+            with h5py.File(stats_file, mode="w") as stats_h5:
+                nisarqa.setup_stats_h5_all_products(
+                    product=product, stats_h5=stats_h5, root_params=root_params
+                )
+
+            # Add file metadata and title page to report PDF.
+            nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
         if root_params.workflows.qa_reports:
             log.info(f"Beginning `qa_reports` processing...")
@@ -144,8 +141,6 @@ def verify_gslc(
             log.info(f"Browse image kml file saved to {browse_file_kml}")
 
             with h5py.File(stats_file, mode="r+") as stats_h5:
-                # Add file metadata and title page to report PDF.
-                nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
                 # Save frequency/polarization info to stats file
                 nisarqa.save_nisar_freq_metadata_to_h5(

--- a/src/nisarqa/products/gslc.py
+++ b/src/nisarqa/products/gslc.py
@@ -104,6 +104,17 @@ def verify_gslc(
         if not verbose:
             print(msg)
 
+    # If running these workflows, save the processing parameters and
+    # identification group to STATS.h5
+    if root_params.workflows.qa_reports or root_params.workflows.point_target:
+        # This is the first time opening the STATS.h5 file for GSLC
+        # workflow, so open in 'w' mode.
+        # After this, always open STATS.h5 in 'r+' mode.
+        with h5py.File(stats_file, mode="w") as stats_h5:
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
+            )
+
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -148,16 +148,9 @@ def verify_igram(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info to stats file
             product.save_qa_metadata_to_h5(stats_h5=stats_h5)

--- a/src/nisarqa/products/igram.py
+++ b/src/nisarqa/products/igram.py
@@ -74,6 +74,7 @@ def verify_igram(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    use_cache = root_params.software_config.use_cache
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -86,12 +87,12 @@ def verify_igram(
 
     try:
         if product_type == "rifg":
-            product = nisarqa.RIFG(input_file)
+            product = nisarqa.RIFG(input_file, use_cache=use_cache)
         elif product_type == "runw":
-            product = nisarqa.RUNW(input_file)
+            product = nisarqa.RUNW(input_file, use_cache=use_cache)
         else:
             assert product_type == "gunw"
-            product = nisarqa.GUNW(input_file)
+            product = nisarqa.GUNW(input_file, use_cache=use_cache)
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -140,16 +140,9 @@ def verify_offset(
             # Add file metadata and title page to report PDF.
             nisarqa.setup_report_pdf(product=product, report_pdf=report_pdf)
 
-            # Save the processing parameters to the stats.h5 file
-            root_params.save_processing_params_to_stats_h5(
-                h5_file=stats_h5, band=product.band
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
             )
-            log.info(f"QA Processing Parameters saved to {stats_file}")
-
-            nisarqa.copy_identification_group_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file Identification group copied to {stats_file}")
 
             # Save frequency/polarization info to stats file
             product.save_qa_metadata_to_h5(stats_h5=stats_h5)

--- a/src/nisarqa/products/offsets.py
+++ b/src/nisarqa/products/offsets.py
@@ -61,6 +61,7 @@ def verify_offset(
     report_file = out_dir / root_params.get_report_pdf_filename()
     stats_file = out_dir / root_params.get_stats_h5_filename()
     summary_file = out_dir / root_params.get_summary_csv_filename()
+    use_cache = root_params.software_config.use_cache
 
     msg = f"Starting Quality Assurance for input file: {input_file}"
     log.info(msg)
@@ -70,13 +71,12 @@ def verify_offset(
     # Initialize the PASS/FAIL checks summary file
     nisarqa.setup_summary_csv(summary_file)
     summary = nisarqa.get_summary()
-
     try:
         if product_type == "roff":
-            product = nisarqa.ROFF(input_file)
+            product = nisarqa.ROFF(input_file, use_cache=use_cache)
         else:
             assert product_type == "goff"
-            product = nisarqa.GOFF(input_file)
+            product = nisarqa.GOFF(input_file, use_cache=use_cache)
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -71,7 +71,11 @@ def verify_rslc(
 
     try:
         # All worksflows use the RSLC() product; only initialize once.
-        product = nisarqa.RSLC(filepath=input_file)
+        product = nisarqa.RSLC(
+            filepath=input_file,
+            use_cache=root_params.software_config.use_cache,
+            # prime_the_cache=True,  # we analyze all images, so prime the cache
+        )
     except:
         # Input product could not be opened via the product reader.
         summary.check_can_open_input_file(result="FAIL")

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -118,6 +118,31 @@ def verify_rslc(
         if not verbose:
             print(msg)
 
+<<<<<<< HEAD
+=======
+    # If running these workflows, save the processing parameters and
+    # identification group to STATS.h5
+    if (
+        root_params.workflows.qa_reports
+        or root_params.workflows.abs_cal
+        or root_params.workflows.neb
+        or root_params.workflows.point_target
+    ):
+        # This is the first time opening the STATS.h5 file for RSLC
+        # workflow, so open in 'w' mode.
+        # After this, always open STATS.h5 in 'r+' mode.
+        with h5py.File(stats_file, mode="w") as stats_h5:
+
+            nisarqa.setup_stats_h5_all_products(
+                product=product, stats_h5=stats_h5, root_params=root_params
+            )
+
+            nisarqa.copy_rfi_metadata_to_stats_h5(
+                product=product, stats_h5=stats_h5
+            )
+            log.info(f"Input file RFI metadata copied to {stats_file}")
+
+>>>>>>> 5037f38 (copy source runconfig. modularize stats.h5 setup)
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be

--- a/src/nisarqa/products/rslc.py
+++ b/src/nisarqa/products/rslc.py
@@ -118,31 +118,6 @@ def verify_rslc(
         if not verbose:
             print(msg)
 
-<<<<<<< HEAD
-=======
-    # If running these workflows, save the processing parameters and
-    # identification group to STATS.h5
-    if (
-        root_params.workflows.qa_reports
-        or root_params.workflows.abs_cal
-        or root_params.workflows.neb
-        or root_params.workflows.point_target
-    ):
-        # This is the first time opening the STATS.h5 file for RSLC
-        # workflow, so open in 'w' mode.
-        # After this, always open STATS.h5 in 'r+' mode.
-        with h5py.File(stats_file, mode="w") as stats_h5:
-
-            nisarqa.setup_stats_h5_all_products(
-                product=product, stats_h5=stats_h5, root_params=root_params
-            )
-
-            nisarqa.copy_rfi_metadata_to_stats_h5(
-                product=product, stats_h5=stats_h5
-            )
-            log.info(f"Input file RFI metadata copied to {stats_file}")
-
->>>>>>> 5037f38 (copy source runconfig. modularize stats.h5 setup)
     # Both the `qa_reports` and/or `point_target` steps may generate a report
     # PDF. If both are workflows are enabled, this can cause an issue, since
     # closing and re-opening a `PdfPages` object causes the file to be

--- a/src/nisarqa/utils/calc.py
+++ b/src/nisarqa/utils/calc.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import namedtuple
 from collections.abc import Sequence
 
 import h5py

--- a/src/nisarqa/utils/input_verification.py
+++ b/src/nisarqa/utils/input_verification.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import os
 import re
-from datetime import datetime
 from typing import Any
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike
 
 import nisarqa
 

--- a/src/nisarqa/utils/metadata_checks.py
+++ b/src/nisarqa/utils/metadata_checks.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import traceback
 from dataclasses import dataclass
 from itertools import chain
-from typing import TypeVar
 
 import h5py
 import numpy as np
 from osgeo import gdal, osr
 
 import nisarqa
+from nisarqa.utils.typing import MetadataLUTT
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -441,7 +441,7 @@ def is_gdal_friendly(input_filepath: str, ds_path: str) -> bool:
         return False
 
 
-def _lut_has_finite_pixels(ds: nisarqa.typing.MetadataLUTT) -> bool:
+def _lut_has_finite_pixels(ds: MetadataLUTT) -> bool:
     """
     Return False if LUT contains all non-finite values; True otherwise.
 
@@ -481,7 +481,7 @@ def _lut_has_finite_pixels(ds: nisarqa.typing.MetadataLUTT) -> bool:
     return True
 
 
-def _lut_is_not_all_zeros(ds: nisarqa.typing.MetadataLUTT) -> bool:
+def _lut_is_not_all_zeros(ds: MetadataLUTT) -> bool:
     """
     Return False if metadata LUT contains all near-zeros; True otherwise.
 

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -36,6 +36,11 @@ def add_metadata_to_report_pdf(
         Input NISAR product.
     report_pdf : matplotlib.backends.backend_pdf.PdfPages
         The output PDF file to set the global metadata for.
+
+    See Also
+    --------
+    nisarqa.utils.stats_h5_writer.setup_writer.add_global_metadata_to_stats_h5
+        Sister function which adds global metadata to the STATS.h5 file.
     """
     product_type = product.product_type.upper()
 

--- a/src/nisarqa/utils/plotting.py
+++ b/src/nisarqa/utils/plotting.py
@@ -107,25 +107,14 @@ def add_title_page_to_report_pdf(
                 # granule ID is part of the title; do not repeat in the table
                 continue
 
-            # convert val to a string
+            # Read the value, then convert to its string representation
             v = val[()]
-            if np.issubdtype(v.dtype, np.bytes_):
-                if val.shape == ():
-                    # dataset is scalar, not a list
-                    v = nisarqa.byte_string_to_python_str(v)
-                else:
-                    # list of byte strings
-                    # Step 1: Format as a list that prints with commas
-                    v = [
-                        nisarqa.byte_string_to_python_str(my_str)
-                        for my_str in v
-                    ]
-                    # Step 2: Put into its string representation
-                    v = str(v)
 
-            else:
-                # numeric, etc dtype
-                v = str(v)
+            if np.issubdtype(v.dtype, np.bytes_):
+                # decode scalar byte strings and arrays of byte strings
+                v = nisarqa.byte_string_to_python_str(v)
+
+            v = str(v)
 
             if len(v) > 30:
                 # Value is too long for a visually-appealing table.

--- a/src/nisarqa/utils/raster_classes.py
+++ b/src/nisarqa/utils/raster_classes.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import numbers
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from functools import cached_property
-from typing import Any, Optional, overload
+from typing import Any, Optional, Sequence, overload
 
 import h5py
 import numpy as np
@@ -139,6 +138,10 @@ class ComplexFloat16Decoder(object):
         original = self.dataset.__repr__()
         new = original.replace("HDF5 dataset", "ComplexFloat16Decoder")
         return new
+
+    @property
+    def chunks(self) -> Sequence[int]:
+        return self.dataset.chunks
 
 
 @dataclass

--- a/src/nisarqa/utils/sanity_checks.py
+++ b/src/nisarqa/utils/sanity_checks.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Container
-from typing import Any, TypeVar
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike
 
 import nisarqa
+from nisarqa.utils.typing import T
 
 objects_to_skip = nisarqa.get_all(name=__name__)
 
@@ -87,8 +86,8 @@ def identification_sanity_checks(
         return True
 
     def _verify_data_is_in_list(
-        value: nisarqa.typing.T | None,
-        valid_options: Container[nisarqa.typing.T],
+        value: T | None,
+        valid_options: Container[T],
         ds_name: str,
     ) -> bool:
         if (value is None) or (value not in valid_options):

--- a/src/nisarqa/utils/stats_h5_writer/metrics_writer.py
+++ b/src/nisarqa/utils/stats_h5_writer/metrics_writer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import h5py
-import numpy as np
 
 import nisarqa
 

--- a/src/nisarqa/utils/stats_h5_writer/stats_h5_globals.py
+++ b/src/nisarqa/utils/stats_h5_writer/stats_h5_globals.py
@@ -17,6 +17,9 @@ STATS_H5_QA_FREQ_GROUP = (
     STATS_H5_QA_DATA_GROUP + "/frequency%s"
 )  # Two '%s' here!
 
+# Input Granule Source Data group (for copying Datasets verbatim)
+STATS_H5_SOURCE_DATA = STATS_H5_BASE_GROUP + "/sourceData"
+
 # RFI Group
 STATS_H5_RFI_BASE_GROUP = STATS_H5_BASE_GROUP + "/RFI"
 STATS_H5_RFI_DATA_GROUP = STATS_H5_RFI_BASE_GROUP + data_group
@@ -53,6 +56,7 @@ __all__ = [
     "STATS_H5_QA_PROCESSING_GROUP",
     "STATS_H5_QA_DATA_GROUP",
     "STATS_H5_QA_FREQ_GROUP",
+    "STATS_H5_SOURCE_DATA",
     "STATS_H5_RFI_BASE_GROUP",
     "STATS_H5_RFI_DATA_GROUP",
     "STATS_H5_ABSCAL_STATS_H5_BASE_GROUP",

--- a/src/nisarqa/utils/summary_csv.py
+++ b/src/nisarqa/utils/summary_csv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 
 import nisarqa
 

--- a/src/nisarqa/utils/tiling.py
+++ b/src/nisarqa/utils/tiling.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import Optional
 
 import numpy as np
@@ -727,8 +727,6 @@ def compute_az_spectra_by_tiling(
 
     To reduce processing time, users can decrease the interval of `col_indices`.
     """
-    log = nisarqa.get_logger()
-
     arr_shape = np.shape(arr)
     if len(arr_shape) != 2:
         raise ValueError(


### PR DESCRIPTION
This PR addresses https://github.com/isce-framework/nisarqa/issues/18.

Currently, the QA STATS.h5 file does not contain global Attributes. This PR adds that metadata.

Code updates to support this feature:
* Implement new function `add_global_metadata_to_stats_h5()`, which is responsible for adding the global Attributes. Add that function to the `setup_stats_h5_all_products()` function, so that it is called during all QA SAS workflows.
* Refactor `create_dataset_in_h5group()`, so that the logic for prepping Dataset and Attribute values is modularized into a new private function, `_prep_data_for_hdf5_using_nisar_conventions()`.
* Create a new function `add_attribute_to_h5_object()`, which can be called by both `add_global_metadata_to_stats_h5()` and `create_dataset_in_h5group()` to ensure that NISAR conventions are followed for Attributes.